### PR TITLE
refactor: reduce boilerplate and memory usage across bindings

### DIFF
--- a/src/bindings/metadata/hashtable.rs
+++ b/src/bindings/metadata/hashtable.rs
@@ -23,7 +23,7 @@ impl<J: Borrow<Jvm>> Metadata<J> {
     pub fn get<T: DeserializeOwned + 'static>(&self, key: &str) -> Result<Option<T>, BindingError> {
         let jvm = self.jvm.borrow();
         let res = jvm.invoke(&self.inner, "get", &[InvocationArg::try_from(key)?])?;
-        if is_null(self.jvm.borrow(), &res)? {
+        if is_null(jvm, &res)? {
             Ok(None)
         } else {
             let res: T = jvm.to_rust(res)?;

--- a/src/bindings/metadata/omexml.rs
+++ b/src/bindings/metadata/omexml.rs
@@ -1,6 +1,20 @@
 use crate::bindings::{error::BindingError, utils::is_null};
 use j4rs::{Instance, InvocationArg, Jvm};
+use serde::de::DeserializeOwned;
 use std::borrow::Borrow;
+
+/// Deserializes a Java result into `Some(value)`, or returns `None` when the
+/// underlying Java reference is `null`.
+fn nullable<T: DeserializeOwned + 'static>(
+    jvm: &Jvm,
+    instance: Instance,
+) -> Result<Option<T>, BindingError> {
+    if is_null(jvm, &instance)? {
+        Ok(None)
+    } else {
+        Ok(Some(jvm.to_rust(instance)?))
+    }
+}
 
 pub struct OmeXmlMetadata<J: Borrow<Jvm>> {
     jvm: J,
@@ -52,59 +66,19 @@ impl<J: Borrow<Jvm>> OmeXmlMetadata<J> {
     }
 
     pub fn get_microscope_manufacturer(&self, image: i32) -> Result<Option<String>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getMicroscopeManufacturer",
-            &[InvocationArg::try_from(image)?.into_primitive()?],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image("getMicroscopeManufacturer", image)
     }
 
     pub fn get_microscope_model(&self, image: i32) -> Result<Option<String>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getMicroscopeModel",
-            &[InvocationArg::try_from(image)?.into_primitive()?],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image("getMicroscopeModel", image)
     }
 
     pub fn get_microscope_serial_number(&self, image: i32) -> Result<Option<String>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getMicroscopeSerialNumber",
-            &[InvocationArg::try_from(image)?.into_primitive()?],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image("getMicroscopeSerialNumber", image)
     }
 
     pub fn get_detector_count(&self, image: i32) -> Result<Option<i32>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getDetectorCount",
-            &[InvocationArg::try_from(image)?.into_primitive()?],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image("getDetectorCount", image)
     }
 
     pub fn get_detector_serial_number(
@@ -112,20 +86,7 @@ impl<J: Borrow<Jvm>> OmeXmlMetadata<J> {
         image: i32,
         detector: i32,
     ) -> Result<Option<String>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getDetectorSerialNumber",
-            &[
-                InvocationArg::try_from(image)?.into_primitive()?,
-                InvocationArg::try_from(detector)?.into_primitive()?,
-            ],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image_detector("getDetectorSerialNumber", image, detector)
     }
 
     pub fn get_detector_model(
@@ -133,20 +94,7 @@ impl<J: Borrow<Jvm>> OmeXmlMetadata<J> {
         image: i32,
         detector: i32,
     ) -> Result<Option<String>, BindingError> {
-        let jvm = self.jvm.borrow();
-        let res = jvm.invoke(
-            &self.inner,
-            "getDetectorModel",
-            &[
-                InvocationArg::try_from(image)?.into_primitive()?,
-                InvocationArg::try_from(detector)?.into_primitive()?,
-            ],
-        )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        self.invoke_image_detector("getDetectorModel", image, detector)
     }
 
     pub fn get_detector_manufacturer(
@@ -154,20 +102,43 @@ impl<J: Borrow<Jvm>> OmeXmlMetadata<J> {
         image: i32,
         detector: i32,
     ) -> Result<Option<String>, BindingError> {
+        self.invoke_image_detector("getDetectorManufacturer", image, detector)
+    }
+
+    /// Invokes a Java getter taking a single `image` index and deserializes the
+    /// nullable result.
+    fn invoke_image<T: DeserializeOwned + 'static>(
+        &self,
+        method: &str,
+        image: i32,
+    ) -> Result<Option<T>, BindingError> {
         let jvm = self.jvm.borrow();
         let res = jvm.invoke(
             &self.inner,
-            "getDetectorManufacturer",
+            method,
+            &[InvocationArg::try_from(image)?.into_primitive()?],
+        )?;
+        nullable(jvm, res)
+    }
+
+    /// Invokes a Java getter taking `image` and `detector` indices and
+    /// deserializes the nullable result.
+    fn invoke_image_detector<T: DeserializeOwned + 'static>(
+        &self,
+        method: &str,
+        image: i32,
+        detector: i32,
+    ) -> Result<Option<T>, BindingError> {
+        let jvm = self.jvm.borrow();
+        let res = jvm.invoke(
+            &self.inner,
+            method,
             &[
                 InvocationArg::try_from(image)?.into_primitive()?,
                 InvocationArg::try_from(detector)?.into_primitive()?,
             ],
         )?;
-        if is_null(jvm, &res)? {
-            Ok(None)
-        } else {
-            Ok(Some(jvm.to_rust(res)?))
-        }
+        nullable(jvm, res)
     }
 
     // TODO: Impl more methods here is the full list:

--- a/src/bindings/reader/format.rs
+++ b/src/bindings/reader/format.rs
@@ -3,6 +3,7 @@ use crate::bindings::{
     metadata::{Metadata, OmeXmlMetadata},
 };
 use j4rs::{Instance, InvocationArg, Jvm};
+use serde::de::DeserializeOwned;
 use std::borrow::Borrow;
 
 // This is a helper trait that is used to get the instance reference of the reader.
@@ -10,6 +11,21 @@ use std::borrow::Borrow;
 pub trait ReaderInstance {
     fn instance_ref(&self) -> &Instance;
     fn instance(self) -> Instance;
+}
+
+/// Invokes a no-argument Java method on the reader instance and deserializes the
+/// returned value into the requested Rust type.
+///
+/// This centralizes the `borrow -> invoke -> to_rust` boilerplate shared by the
+/// many simple getters exposed through [`FormatReader`].
+fn call_no_args<R, T>(reader: &R, method: &str) -> Result<T, BindingError>
+where
+    R: Borrow<Jvm> + ReaderInstance + ?Sized,
+    T: DeserializeOwned + 'static,
+{
+    let jvm = reader.borrow();
+    let res = jvm.invoke(reader.instance_ref(), method, InvocationArg::empty())?;
+    Ok(jvm.to_rust(res)?)
 }
 
 /// This trait is used as the common interface for all the readers.
@@ -28,211 +44,127 @@ pub trait FormatReader: Borrow<Jvm> + ReaderInstance {
 
     /// Return whether resolution flattening is enabled.
     fn has_flattened_resolutions(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "hasFlattenedResolutions",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "hasFlattenedResolutions")
     }
 
     /// Gets the number of channels returned with each call to openBytes.
     /// The most common case where this value is greater than 1 is for interleaved RGB data, such as a 24-bit color image plane.
     /// However, it is possible for this value to be greater than 1 for non-interleaved data, such as an RGB TIFF with Planar rather than Chunky configuration.
     fn get_rgb_channel_count(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getRGBChannelCount",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getRGBChannelCount")
     }
 
     /// Gets whether the channels are interleaved.
     fn is_interleaved(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "isInterleaved", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "isInterleaved")
     }
 
     /// Gets whether the data is in little-endian format
     fn is_little_endian(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "isLittleEndian",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "isLittleEndian")
     }
 
     /// Returns the optimal sub-image width for use with openBytes
     fn get_optimal_tile_width(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getOptimalTileWidth",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getOptimalTileWidth")
     }
 
     /// Returns the optimal sub-image height for use with openBytes
     fn get_optimal_tile_height(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getOptimalTileHeight",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getOptimalTileHeight")
     }
 
     /// Gets the pixel type
     fn get_pixel_type(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getPixelType", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getPixelType")
     }
 
     /// Gets a five-character string representing the dimension order in which planes will be returned
     /// Example: XYCZT
     fn get_dimension_order(&self) -> Result<String, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getDimensionOrder",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getDimensionOrder")
     }
 
     /// Gets the name of this file format
     fn get_format(&self) -> Result<String, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getFormat", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getFormat")
     }
 
     /// Determines the number of image planes in the current file.
     fn get_image_count(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getImageCount", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getImageCount")
     }
 
     /// Get the current resolution level
     fn get_resolution(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getResolution", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getResolution")
     }
 
     /// Gets the currently active series
     fn get_series(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSeries", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSeries")
     }
 
     /// Return the number of resolutions for the current series.
     /// Resolutions are stored in descending order, so the largest resolution is first and the smallest resolution is last.
     fn get_resolution_count(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getResolutionCount",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getResolutionCount")
     }
 
     /// Gets the number of series in this file.
     fn get_series_count(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "getSeriesCount",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSeriesCount")
     }
 
     /// Gets the size of the X dimension.
     fn get_size_x(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSizeX", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSizeX")
     }
 
     /// Gets the size of the Y dimension.
     fn get_size_y(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSizeY", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSizeY")
     }
 
     /// Gets the size of the Z dimension.
     fn get_size_z(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSizeZ", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSizeZ")
     }
 
     /// Gets the size of the C/Channel dimension.
     fn get_size_c(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSizeC", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSizeC")
     }
 
     /// Gets the size of the T/Time dimension.
     fn get_size_t(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getSizeT", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getSizeT")
     }
 
     /// Get the size of the X dimension for the thumbnail
     fn get_thumb_size_x(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getThumbSizeX", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getThumbSizeX")
     }
 
     /// Get the size of the Y dimension for the thumbnail
     fn get_thumb_size_y(&self) -> Result<i32, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "getThumbSizeY", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "getThumbSizeY")
     }
 
     /// Gets whether the image planes are indexed color.
     fn is_indexed(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "isIndexed", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "isIndexed")
     }
 
     /// Checks if the image planes in the file have more than one channel per `open_bytes` call.
     /// This method returns true if and only if getRGBChannelCount() returns a value greater than 1.
     fn is_rgb(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(self.instance_ref(), "isRGB", InvocationArg::empty())?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "isRGB")
     }
 
     /// Gets whether the current series is a lower resolution copy of a different series
     fn is_thumbnail_series(&self) -> Result<bool, BindingError> {
-        let jvm = self.borrow();
-        let res = jvm.invoke(
-            self.instance_ref(),
-            "isThumbnailSeries",
-            InvocationArg::empty(),
-        )?;
-        Ok(jvm.to_rust(res)?)
+        call_no_args(self, "isThumbnailSeries")
     }
 
     /// Gets the rasterized index corresponding to the given Z, C and T coordinates (real sizes).

--- a/src/extra/utils.rs
+++ b/src/extra/utils.rs
@@ -119,7 +119,7 @@ pub(crate) fn planar_to_interleaved_rgb(image: RgbImage) -> RgbImage {
     let mut inter_image = RgbImage::new(image.width(), image.height());
     let size = image.width() * image.height();
     for i in 0..size as usize {
-        inter_image.as_mut()[i * 3] = image.as_ref()[i + 0 * w * h];
+        inter_image.as_mut()[i * 3] = image.as_ref()[i];
         inter_image.as_mut()[i * 3 + 1] = image.as_ref()[i + w * h];
         inter_image.as_mut()[i * 3 + 2] = image.as_ref()[i + 2 * w * h];
     }
@@ -132,7 +132,7 @@ pub(crate) fn planar_to_interleaved_rgba(image: RgbaImage) -> RgbaImage {
     let mut inter_image = RgbaImage::new(image.width(), image.height());
     let size = image.width() * image.height();
     for i in 0..size as usize {
-        inter_image.as_mut()[i * 4] = image.as_ref()[i + 0 * w * h];
+        inter_image.as_mut()[i * 4] = image.as_ref()[i];
         inter_image.as_mut()[i * 4 + 1] = image.as_ref()[i + w * h];
         inter_image.as_mut()[i * 4 + 2] = image.as_ref()[i + 2 * w * h];
         inter_image.as_mut()[i * 4 + 3] = image.as_ref()[i + 3 * w * h];

--- a/src/extra/wsi/deepzoom.rs
+++ b/src/extra/wsi/deepzoom.rs
@@ -100,7 +100,7 @@ impl<I: FormatReader, B: Borrow<BioformatsSlide<I>>> DeepZoomGenerator<I, B> {
             tile_size,
             l0_offset,
             level_dimensions,
-            slide_level_dimensions: slide_level_dimensions.clone(),
+            slide_level_dimensions,
             level_tiles,
             level_count,
             slide_from_dz_level,

--- a/src/extra/wsi/slide.rs
+++ b/src/extra/wsi/slide.rs
@@ -143,6 +143,16 @@ impl<T: FormatReader> BioformatsSlide<T> {
         )?)
     }
 
+    /// Same as [`BioformatsSlide::read_region`] but returns the raw pixel buffer
+    /// as `u8` instead of `i8`.
+    ///
+    /// This is a zero-copy reinterpretation of the underlying bytes (no extra
+    /// allocation), which is convenient when feeding the buffer into APIs that
+    /// expect unsigned bytes.
+    pub fn read_region_u8(&self, region: &Region) -> Result<Vec<u8>, WSIError> {
+        Ok(vec_i8_into_u8(self.read_region(region)?))
+    }
+
     /// Copy pixel data from a whole slide image.
     ///
     /// This function reads and decompresses a region of a whole slide image into a `DynamicImage`
@@ -257,16 +267,15 @@ fn compute_all_level_dimensions<T: FormatReader>(reader: &T) -> Result<Vec<Size>
 }
 
 fn compute_all_level_downsamples(level_dimensions: &[Size]) -> Vec<f64> {
-    let nb_level = level_dimensions.len();
-    let dim_0 = level_dimensions.first().expect("");
-    let mut downsamples = Vec::with_capacity(nb_level);
-    for level in 0..nb_level {
-        let dim = level_dimensions.get(level).expect("");
-        downsamples.push(
-            (f64::from(dim_0.w) / f64::from(dim.w)).min(f64::from(dim_0.h) / f64::from(dim.h)),
-        );
-    }
-    downsamples
+    let Some(dim_0) = level_dimensions.first() else {
+        return Vec::new();
+    };
+    level_dimensions
+        .iter()
+        .map(|dim| {
+            (f64::from(dim_0.w) / f64::from(dim.w)).min(f64::from(dim_0.h) / f64::from(dim.h))
+        })
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- format.rs: extract call_no_args helper, collapsing ~24 repetitive
  no-arg getter implementations into one-liners
- omexml.rs: add nullable + invoke_image/invoke_image_detector helpers
  to dedupe the repeated null-check/deserialize pattern
- deepzoom.rs: drop redundant clone of slide_level_dimensions (moved
  straight into the struct, saving an allocation)
- slide.rs: rewrite compute_all_level_downsamples to iterate without
  index lookups and empty-message expect() panics; add zero-copy
  read_region_u8 convenience method
- hashtable.rs: reuse the already-borrowed Jvm instead of borrowing twice
- utils.rs: drop identity_op (i + 0 * w * h)